### PR TITLE
use o3 model for gpte code

### DIFF
--- a/src/gpte.app.src
+++ b/src/gpte.app.src
@@ -1,6 +1,6 @@
 {application, gpte,
  [{description, "An OTP library"},
-  {vsn, "1.10.0"},
+  {vsn, "1.10.1"},
   {registered, []},
   {applications,
    [kernel,

--- a/src/gpte_code.erl
+++ b/src/gpte_code.erl
@@ -24,7 +24,7 @@ cli() ->
 -spec cli(opt()) -> chat_gpte:chat().
 cli(Opt) ->
     Chat0 = chat_gpte:new(),
-    Chat10 = chat_gpte:model(<<"o3-mini">>, Chat0),
+    Chat10 = chat_gpte:model(<<"o3">>, Chat0),
     Chat20 = chat_gpte:temperature(1, Chat10),
     Chat30 = chat_gpte:on_moderation_flagged(fun(Reason, C)->
         klsn_io:format("prompt_potentially_harmful:~n~p~n", [Reason]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default model used for chat sessions to "o3" for improved interactions.

- **Chores**
  - Incremented the application version to 1.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->