### PR TITLE
rename field description to gpte_field_description

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ optionally, you can add description of the type and each field.
 ```
 
 ```erlang
--gpte_type_description([
+-gpte_field_description([
         {sample/0, [], <<"sample object with 10 fields.">>}
       , {sample/0, [unicode_field], <<"field value must be `ユニコード`."/utf8>>}
       , {sample/0, [binstr_field], <<"field value must be `binstr value`.">>}

--- a/src/gpte_schema.erl
+++ b/src/gpte_schema.erl
@@ -33,7 +33,7 @@
       , array_field => [number()]
       , required_boolean_field := boolean()
     }.
--gpte_type_description([
+-gpte_field_description([
         {sample/0, [], <<"sample object with 10 fields.">>}
       , {sample/0, [unicode_field], <<"field value must be `ユニコード`."/utf8>>}
       , {sample/0, [binstr_field], <<"field value must be `binstr value`.">>}
@@ -244,7 +244,7 @@ lookup_type_description({Module, Type, Arity}) ->
 lookup_field_description({Module, Type, Arity, Path}) ->
     Attributes = Module:module_info(attributes),
     Res = lists:filtermap(fun
-        ({gpte_type_description, List})->
+        ({gpte_field_description, List})->
             Descriptions = lists:filtermap(fun
                 ({{Type0, Arity0}, Path0, Description}) when Type0 =:= Type, Arity0 =:= Arity, Path0 =:= Path ->
                     {true, Description};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the example in the documentation to use the proper function name for adding descriptions to Erlang type fields.

- **Bug Fixes**
  - Fixed an issue where field descriptions were not correctly retrieved due to a mismatched attribute name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->