### PR TITLE
can use flex_mode and get raw usage data.

### DIFF
--- a/src/chat_gpte.erl
+++ b/src/chat_gpte.erl
@@ -539,7 +539,7 @@ lookup_last_raw_usage(#{payloads:=[#{<<"usage">>:=Usage}|_]}) ->
 lookup_last_raw_usage(_) ->
     none.
 
--spec list_raw_usage(chat()) -> klsn:maybe(raw_usage()).
+-spec list_raw_usage(chat()) -> [raw_usage()].
 list_raw_usage(#{payloads:=Payloads}) ->
     lists:filtermap(fun
         (#{<<"usage">>:=Usage}) ->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Choose a service tier per chat (auto, default, flex, priority).
  - View raw usage captured from chat payloads: see the latest entry and list all entries.

- **Changes**
  - Default chat model updated to gpt-5-mini.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->